### PR TITLE
split the command field for stdin input

### DIFF
--- a/cronparser_test.go
+++ b/cronparser_test.go
@@ -29,6 +29,7 @@ var parseableLines = map[string]*CronEntry{
 		DayOfWeek: &CronSection{Time: "*"},
 		User:      "root",
 		Command:   "cd / && run-parts --report /etc/cron.hourly",
+		Stdin:     "",
 	},
 	"25 6    * * *   root    test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.daily )": &CronEntry{
 		Minute:    &CronSection{Time: "25"},
@@ -38,6 +39,7 @@ var parseableLines = map[string]*CronEntry{
 		DayOfWeek: &CronSection{Time: "*"},
 		User:      "root",
 		Command:   "test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.daily )",
+		Stdin:     "",
 	},
 	"47 6    * * 7   fart test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.weekly )": &CronEntry{
 		Minute:    &CronSection{Time: "47"},
@@ -47,6 +49,7 @@ var parseableLines = map[string]*CronEntry{
 		DayOfWeek: &CronSection{Time: "7"},
 		User:      "fart",
 		Command:   "test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.weekly )",
+		Stdin:     "",
 	},
 }
 
@@ -186,6 +189,8 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 52 6    1 * *   root    test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.monthly )
 #
 */1 * * * * root /usr/local/rtm/bin/rtm 9 > /dev/null 2> /dev/null
+*/2 * * * * root somecommand >> /tmp/commandlog.$( date +\%Y\%m\%d )
+*/15 * * * * root somecommand >> /tmp/commandlog.$( date +\%Y\%m\%d ) %command has trailing space% stdin line with leading space
 `
 	cp := NewCronParser()
 
@@ -207,6 +212,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 				DayOfWeek: &CronSection{Time: "*"},
 				User:      "root",
 				Command:   "cd / && run-parts --report /etc/cron.hourly",
+				Stdin:     "",
 			},
 			&CronEntry{
 				Minute:    &CronSection{Time: "25"},
@@ -216,6 +222,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 				DayOfWeek: &CronSection{Time: "*"},
 				User:      "root",
 				Command:   "test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.daily )",
+				Stdin:     "",
 			},
 			&CronEntry{
 				Minute:    &CronSection{Time: "47"},
@@ -225,6 +232,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 				DayOfWeek: &CronSection{Time: "7"},
 				User:      "root",
 				Command:   "test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.weekly )",
+				Stdin:     "",
 			},
 			&CronEntry{
 				Minute:    &CronSection{Time: "52"},
@@ -234,6 +242,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 				DayOfWeek: &CronSection{Time: "*"},
 				User:      "root",
 				Command:   "test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.monthly )",
+				Stdin:     "",
 			},
 			&CronEntry{
 				Minute:    &CronSection{Time: "*", Interval: "1"},
@@ -243,6 +252,27 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 				DayOfWeek: &CronSection{Time: "*"},
 				User:      "root",
 				Command:   "/usr/local/rtm/bin/rtm 9 > /dev/null 2> /dev/null",
+				Stdin:     "",
+			},
+			&CronEntry{
+				Minute:    &CronSection{Time: "*", Interval: "2"},
+				Hour:      &CronSection{Time: "*"},
+				Day:       &CronSection{Time: "*"},
+				Month:     &CronSection{Time: "*"},
+				DayOfWeek: &CronSection{Time: "*"},
+				User:      "root",
+				Command:   `somecommand >> /tmp/commandlog.$( date +%Y%m%d )`,
+				Stdin:     "",
+			},
+			&CronEntry{
+				Minute:    &CronSection{Time: "*", Interval: "15"},
+				Hour:      &CronSection{Time: "*"},
+				Day:       &CronSection{Time: "*"},
+				Month:     &CronSection{Time: "*"},
+				DayOfWeek: &CronSection{Time: "*"},
+				User:      "root",
+				Command:   `somecommand >> /tmp/commandlog.$( date +%Y%m%d ) `,
+				Stdin:     "command has trailing space\n stdin line with leading space",
 			},
 		},
 	}


### PR DESCRIPTION
Modern crontab(5) supports a little known feature of being able to feed
the command to run input on stdin.  From the man page:

    The  "sixth"  field (the rest of the line) specifies the command to
    be run.  The entire command portion of the line, up to a newline or
    % character, will be executed by /bin/sh or by the shell specified
    in the SHELL variable of the cronfile.  Percent-signs (%) in the
    command, unless escaped with  backslash (\), will be changed into
    newline characters, and all data after the first % will be sent to
    the command as standard input.

Adds a `Stdin` field to the entry struct, which contains a single string
(which may be multiple lines if there were multiple %'s given).

The tests for this includes a use-case I use pretty often, specifically
redirecting output to a dated file.

What's not supported (or tested) is what happens when the command starts
with a %, which is apparently undefined? (or feeds the entire command as
stdin to the shell?).